### PR TITLE
Added existing user error code.

### DIFF
--- a/SPiDSDK/SPiDClient.h
+++ b/SPiDSDK/SPiDClient.h
@@ -83,6 +83,12 @@ static NSString *const AccessTokenKeychainIdentification = @"AccessToken";
  */
 @property(strong, nonatomic) NSURL *signupURL;
 
+/** URL to use for account summary
+ *
+ * This URL is normally generated using the 'serverURL/account/summary'
+ * */
+@property (nonatomic, strong) NSURL *accountSummaryURL;
+
 /** URL to use for web forgot password with SPiD
 
  This URL is normally generated using the `serverURL`/auth/forgotpassword
@@ -159,6 +165,9 @@ static NSString *const AccessTokenKeychainIdentification = @"AccessToken";
 
 /** Redirects to safari for forgot password */
 - (void)browserRedirectForgotPassword; // TODO: does not need completion handler
+
+/** Redirects to safari for forgot password */
+- (void)browserRedirectAccountSummary;
 
 /** Redirects to safari for logout
 

--- a/SPiDSDK/SPiDClient.m
+++ b/SPiDSDK/SPiDClient.m
@@ -106,6 +106,9 @@ static SPiDClient *sharedSPiDClientInstance = nil;
 
     if (![sharedSPiDClientInstance signupURL])
         [sharedSPiDClientInstance setSignupURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@/auth/signup", [sharedSPiDClientInstance serverURL]]]];
+    
+    if (![sharedSPiDClientInstance accountSummaryURL])
+        [sharedSPiDClientInstance setAccountSummaryURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@/account/summary?client_id=%@", [sharedSPiDClientInstance serverURL], clientID]]];
 
     if (![sharedSPiDClientInstance forgotPasswordURL])
         [sharedSPiDClientInstance setForgotPasswordURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@/auth/forgotpassword", [sharedSPiDClientInstance serverURL]]]];
@@ -157,6 +160,15 @@ static SPiDClient *sharedSPiDClientInstance = nil;
     NSURL *requestURL = [self forgotPasswordURLWithQuery];
     SPiDDebugLog(@"Trying to authorize using browser redirect: %@", requestURL);
     [[UIApplication sharedApplication] openURL:requestURL];
+}
+
+- (void)browserRedirectAccountSummary {
+    NSURL *requestURL = [self accountSummaryURL];
+
+    SPiDDebugLog(@"Trying to open account summary: %@", requestURL);
+    if([[UIApplication sharedApplication] canOpenURL:requestURL]) {
+       [[UIApplication sharedApplication] openURL:requestURL];
+    }
 }
 
 - (void)browserRedirectLogoutWithCompletionHandler:(void (^)(SPiDError *response))completionHandler {

--- a/SPiDSDK/SPiDError.h
+++ b/SPiDSDK/SPiDError.h
@@ -51,10 +51,11 @@
 
 /**
 
- @param errorString Error string.
+ @param errorDomain Error domain string.
+ @param error code from api or 0
  @return Returns internal SPiD code for the given error.
  */
-+ (NSInteger)getSPiDOAuth2ErrorCode:(NSString *)errorString;
++ (NSInteger)getSPiDOAuth2ErrorCodeFromDomain:(NSString *)errorDomain andAPIErrorCode:(NSInteger)apiError;
 
 + (id)errorFromNSError:(NSError *)error;
 
@@ -88,6 +89,6 @@ enum {
     SPiDUserAbortedLogin = -1100,
     SPiDJSONParseErrorCode = -1200, // JSON Parse error
 
-    SPiDAPIExceptionErrorCode = -1300
-
+    SPiDAPIExceptionErrorCode = -1300,
+    SPiDAPIExceptionExistingUser = -1302 //User already exists
 };


### PR DESCRIPTION
We wanted to take specific actions if an user tried to create an account with an email that already had an account.
So added an error code for that, SPiDAPIExceptionExistingUser, and necessary check in the api response (302).