### PR TITLE
Dont refresh invalid token

### DIFF
--- a/SPiDSDK/SPiDAccessToken.h
+++ b/SPiDSDK/SPiDAccessToken.h
@@ -78,4 +78,6 @@ extern NSString *const SPiDAccessTokenRefreshTokenKey;
 */
 - (BOOL)isClientToken;
 
+- (BOOL)isValid;
+
 @end

--- a/SPiDSDK/SPiDAccessToken.m
+++ b/SPiDSDK/SPiDAccessToken.m
@@ -18,11 +18,9 @@ NSString *const SPiDAccessTokenRefreshTokenKey = @"refresh_token";
 
 - (BOOL)isValid {
     if (self.accessToken == nil) {
-        SPiDDebugLog(@"Could not create SPiDAccessToken, missing access_token parameter");
         return NO;
     }
     if (self.expiresAt == nil) {
-        SPiDDebugLog(@"Could not create SPiDAccessToken, missing expires_in parameter");
         return NO;
     }
     return YES;
@@ -36,7 +34,12 @@ NSString *const SPiDAccessTokenRefreshTokenKey = @"refresh_token";
         _expiresAt = expiresAt;
         _refreshToken = refreshToken;
 
-        if (![self isValid]) {
+        if (accessToken == nil) {
+            SPiDDebugLog(@"Could not create SPiDAccessToken, missing access_token parameter");
+            return nil;
+        }
+        if (expiresAt == nil) {
+            SPiDDebugLog(@"Could not create SPiDAccessToken, missing expires_in parameter");
             return nil;
         }
     }

--- a/SPiDSDK/SPiDAccessToken.m
+++ b/SPiDSDK/SPiDAccessToken.m
@@ -16,12 +16,12 @@ NSString *const SPiDAccessTokenRefreshTokenKey = @"refresh_token";
 
 @implementation SPiDAccessToken
 
-+ (BOOL)isValidToken:(SPiDAccessToken *)accessToken {
-    if (accessToken.accessToken == nil) {
+- (BOOL)isValid {
+    if (self.accessToken == nil) {
         SPiDDebugLog(@"Could not create SPiDAccessToken, missing access_token parameter");
         return NO;
     }
-    if (accessToken.expiresAt == nil) {
+    if (self.expiresAt == nil) {
         SPiDDebugLog(@"Could not create SPiDAccessToken, missing expires_in parameter");
         return NO;
     }
@@ -36,7 +36,7 @@ NSString *const SPiDAccessTokenRefreshTokenKey = @"refresh_token";
         _expiresAt = expiresAt;
         _refreshToken = refreshToken;
 
-        if (![SPiDAccessToken isValidToken:self]) {
+        if (![self isValid]) {
             return nil;
         }
     }

--- a/SPiDSDK/SPiDClient.h
+++ b/SPiDSDK/SPiDClient.h
@@ -213,6 +213,9 @@ static NSString *const AccessTokenKeychainIdentification = @"AccessToken";
 /** Clears current authorization request and waiting requests */
 - (void)clearAuthorizationRequest;
 
+/** Clears access token and also removes it from the keychain */
+- (void)removeAccessToken;
+
 /** Called when authorization is complete */
 - (void)authorizationComplete;
 

--- a/SPiDSDK/SPiDClient.m
+++ b/SPiDSDK/SPiDClient.m
@@ -465,13 +465,14 @@ static SPiDClient *sharedSPiDClientInstance = nil;
 
 - (void)logoutComplete {
     SPiDDebugLog(@"Logged out from SPiD");
-    self.accessToken = nil;
-
-    [SPiDKeychainWrapper removeAccessTokenFromKeychainForIdentifier:AccessTokenKeychainIdentification];
-
+    [self removeAccessToken];
     [self clearAuthorizationRequest];
-
     self.waitingRequests = nil;
+}
+
+- (void)removeAccessToken {
+    self.accessToken = nil;
+    [SPiDKeychainWrapper removeAccessTokenFromKeychainForIdentifier:AccessTokenKeychainIdentification];
 }
 
 @end

--- a/SPiDSDK/SPiDClient.m
+++ b/SPiDSDK/SPiDClient.m
@@ -261,9 +261,7 @@ static SPiDClient *sharedSPiDClientInstance = nil;
 }
 
 - (BOOL)isAuthorized {
-    if (self.accessToken)
-        return !self.hasTokenExpired;
-    return NO;
+    return [self.accessToken isValid];
 }
 
 - (BOOL)isClientToken {

--- a/SPiDSDK/SPiDRequest.m
+++ b/SPiDSDK/SPiDRequest.m
@@ -145,7 +145,12 @@
             SPiDDebugLog(@"Received response from: %@", [self.URL absoluteString]);
             SPiDResponse *spidResponse = [[SPiDResponse alloc] initWithJSONData:data];
             NSError *spidError = [spidResponse error];
-            if (spidError && ([spidError code] == SPiDOAuth2InvalidTokenErrorCode || [spidError code] == SPiDOAuth2ExpiredTokenErrorCode)) {
+
+            if (spidError && [spidError code] == SPiDOAuth2InvalidTokenErrorCode) {
+                // Caused by the user just changing password
+                [[SPiDClient sharedInstance] removeAccessToken];
+            }
+            if (spidError && [spidError code] == SPiDOAuth2ExpiredTokenErrorCode) {
                 if ([self retryCount] < 3) {
                     SPiDDebugLog(@"Invalid token, trying to refresh");
                     [self setRetryCount:[self retryCount] + 1];


### PR DESCRIPTION
- Refactor code for removing access token into its own method and expose it so that it can be used in SPiDRequest.
- Separate the checks for invalid token and expired token as they should be handled differently. Not having them separate has until now resulted in 3 failed refreshes of the invalid access token every time a request that requires a valid access token is fired. Trying to refresh an invalid access token will give the error invalid_grant every time.
- Better check for if the access token is valid.
